### PR TITLE
Fetch and display missions from api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.8.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
@@ -18,6 +20,7 @@
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
+        "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -2974,6 +2977,29 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4832,6 +4858,28 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15469,6 +15517,14 @@
         "deep-diff": "^0.3.5"
       }
     },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15660,6 +15716,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -20701,6 +20762,17 @@
         "source-map": "^0.7.3"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -22081,6 +22153,27 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -29635,6 +29728,12 @@
         "deep-diff": "^0.3.5"
       }
     },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -29780,6 +29879,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.8.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
@@ -13,6 +15,7 @@
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",
+    "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/Missions.css
+++ b/src/Missions.css
@@ -1,0 +1,26 @@
+button {
+  width: max-content;
+  padding: 5px;
+}
+
+td {
+  padding: 5px;
+  text-align: justify;
+}
+
+td:nth-child(3) {
+  width: 10rem;
+}
+
+.table {
+  margin: 20px auto;
+  width: 80%;
+}
+
+.table-body {
+  color: black;
+}
+
+.table-body tr:nth-child(odd) {
+  background-color: rgb(238, 237, 237);
+}

--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -1,7 +1,57 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux/es/hooks/useDispatch';
+import { useSelector } from 'react-redux/es/exports';
+import { fetchMissions, leaveMissionAction, joinMissionAction } from '../redux/missions/missions';
+import '../Missions.css';
 
-const Missions = () => (
-  <h2>Missons</h2>
-);
+const Missions = () => {
+  const missionData = useSelector((state) => state);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (missionData.length === 0) {
+      dispatch(fetchMissions());
+    }
+  }, []);
+
+  const toggleReservation = (mission) => {
+    if (mission.reserved) {
+      return dispatch(leaveMissionAction(mission.mission_id));
+    }
+    return dispatch(joinMissionAction(mission.mission_id));
+  };
+  const tblHeaders = ['Mission', 'Discription', 'Status', 'Action'];
+  return (
+    <div>
+      <table className="table" border={1} cellSpacing={0}>
+        <thead>
+          <tr>
+            {tblHeaders.map((e) => <th key={e}>{e}</th>)}
+          </tr>
+        </thead>
+        <tbody className="table-body">
+          {missionData.map((mission) => (
+            <tr key={mission.mission_id}>
+              <td>{mission.mission_name}</td>
+              <td>{mission.description}</td>
+              <td>
+                {mission.reserved ? (<span className="member">Active Member</span>) : (<span className="not-member">NOT A MEMBER</span>)}
+              </td>
+              <td>
+                <button
+                  onClick={() => toggleReservation(mission)}
+                  type="button"
+                >
+                  {mission.reserved && 'Leave Mission'}
+                  {!mission.reserved && 'Join Mission'}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 export default Missions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import store from './redux/configureStore';
 
 import App from './App';
 
@@ -8,7 +10,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <Router>
-      <App />
+      <Provider store={store}>
+        <App />
+      </Provider>
     </Router>
   </React.StrictMode>,
 );

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,0 +1,6 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { missionReducer } from './missions/missions';
+
+const store = configureStore({ reducer: missionReducer });
+
+export default store;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,0 +1,50 @@
+import axios from 'axios';
+
+const FETCH_MISSIONS = 'Space-Travellers-Hub/missions/FETCH_MISSIONS';
+const JOIN_MISSION = 'Space-Travellers-Hub/missions/JOIN_MISSION';
+const LEAVE_MISSION = 'Space-Travellers-Hub/missions/LEAVE_MISSION';
+const url = 'https://api.spacexdata.com/v3/missions';
+const initialState = [];
+
+export const joinMissionAction = (missionId) => ({
+  type: JOIN_MISSION,
+  payload: missionId,
+});
+
+export const leaveMissionAction = (missionId) => ({
+  type: LEAVE_MISSION,
+  payload: missionId,
+});
+
+export const fetchMissionAction = (mission) => ({
+  type: FETCH_MISSIONS,
+  payload: mission,
+});
+
+export const fetchMissions = () => async (dispatch) => {
+  const response = await axios.get(url);
+  dispatch(fetchMissionAction(response.data));
+};
+
+export const missionReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_MISSIONS:
+      return action.payload;
+    case JOIN_MISSION:
+      return state.map((mission) => {
+        if (mission.mission_id === action.payload) {
+          return { ...mission, reserved: true };
+        }
+        return mission;
+      });
+    case LEAVE_MISSION:
+      return state.map((mission) => {
+        if (mission.mission_id === action.payload) {
+          return { ...mission, reserved: false };
+        }
+        return mission;
+      });
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
## Issue ticket number and link
#18 
#15 

### What kind of change does this PR introduce?
- Fetch data from the [Missions endpoint](https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
-  Store the selected data in Redux store.
- Use `useSelector()` Redux Hook to select the state slices and render lists of missions in corresponding routes.
- Style the whole application.
- Render a table with the missions' data (as per design).

closes #18, #15